### PR TITLE
linter: add deprecation code check, linter declarations

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -106,7 +106,7 @@ const {
 const linter = createLinter(lintDryRun, disableRule);
 
 const { loadFiles } = createMarkdownLoader();
-const { parseApiDocs } = createMarkdownParser();
+const { parseApiDocs } = createMarkdownParser(linter);
 
 const apiDocFiles = await loadFiles(input, ignore);
 

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -425,4 +425,9 @@ export const LINT_MESSAGES = {
   missingIntroducedIn: "Missing 'introduced_in' field in the API doc entry",
   missingChangeVersion: 'Missing version field in the API doc entry',
   invalidChangeVersion: 'Invalid version number: {{version}}',
+  malformedDeprecationHeader: 'Malformed deprecation header',
+  outOfOrderDeprecationCode:
+    "Deprecation code '{{code}}' out of order (expected {{expectedCode}})",
+  invalidLinterDeclaration: "Invalid linter declaration '{{declaration}}'",
+  malformedLinterDeclaration: 'Malformed linter declaration: {{message}}',
 };

--- a/src/generators/legacy-json/types.d.ts
+++ b/src/generators/legacy-json/types.d.ts
@@ -8,7 +8,7 @@ export interface HierarchizedEntry extends ApiDocMetadataEntry {
   /**
    * List of child entries that are part of this entry's hierarchy.
    */
-  hierarchyChildren: ApiDocMetadataEntry[];
+  hierarchyChildren: HierarchizedEntry[];
 }
 
 /**

--- a/src/generators/legacy-json/utils/buildSection.mjs
+++ b/src/generators/legacy-json/utils/buildSection.mjs
@@ -1,4 +1,4 @@
-import { buildHierarchy } from './buildHierarchy.mjs';
+import { buildHierarchy } from '../../../utils/buildHierarchy.mjs';
 import { getRemarkRehype } from '../../../utils/remark.mjs';
 import { transformNodesToString } from '../../../utils/unist.mjs';
 import { parseList } from './parseList.mjs';

--- a/src/linter/constants.mjs
+++ b/src/linter/constants.mjs
@@ -1,0 +1,6 @@
+'use strict';
+
+// Validates a deprecation header from doc/api/deprecation.md and captures the
+// code
+// For example, `DEP0001: `http.OutgoingMessage.prototype.flush` captures `0001`
+export const DEPRECATION_HEADER_REGEX = /DEP(\d{4}): .+?/;

--- a/src/linter/engine.mjs
+++ b/src/linter/engine.mjs
@@ -10,13 +10,15 @@ const createLinterEngine = rules => {
    * Validates a ApiDocMetadataEntry entry against all defined rules
    *
    * @param {ApiDocMetadataEntry} entry
+   * @param {import('./types').LintDeclarations}
+   * @param declarations
    * @returns {import('./types').LintIssue[]}
    */
-  const lint = entry => {
+  const lint = (entry, declarations) => {
     const issues = [];
 
     for (const rule of rules) {
-      const ruleIssues = rule(entry);
+      const ruleIssues = rule([entry], declarations);
 
       if (ruleIssues.length > 0) {
         issues.push(...ruleIssues);
@@ -30,13 +32,19 @@ const createLinterEngine = rules => {
    * Validates an array of ApiDocMetadataEntry entries against all defined rules
    *
    * @param {ApiDocMetadataEntry[]} entries
+   * @param {import('./types').LintDeclarations}
+   * @param declarations
    * @returns {import('./types').LintIssue[]}
    */
-  const lintAll = entries => {
+  const lintAll = (entries, declarations) => {
     const issues = [];
 
-    for (const entry of entries) {
-      issues.push(...lint(entry));
+    for (const rule of rules) {
+      const ruleIssues = rule(entries, declarations);
+
+      if (ruleIssues.length > 0) {
+        issues.push(...ruleIssues);
+      }
     }
 
     return issues;

--- a/src/linter/rules/deprecation-code-order.mjs
+++ b/src/linter/rules/deprecation-code-order.mjs
@@ -1,0 +1,82 @@
+'use strict';
+
+import { LINT_MESSAGES } from '../../constants.mjs';
+import { buildHierarchy } from '../../utils/buildHierarchy.mjs';
+import { DEPRECATION_HEADER_REGEX } from '../constants.mjs';
+import getDeprecationEntries from './utils/getDeprecationEntries.mjs';
+
+/**
+ * @param {ApiDocMetadataEntry} deprecation
+ * @param {number} expectedCode
+ * @returns {Array<import('../types').LintIssue>}
+ */
+function lintDeprecation(deprecation, expectedCode) {
+  // Try validating the header (`DEPXXXX: ...`) and extract the code for us to
+  // look at
+  const match = deprecation.heading.data.text.match(DEPRECATION_HEADER_REGEX);
+
+  if (!match) {
+    // Malformed header
+    return [
+      {
+        level: 'error',
+        location: {
+          path: deprecation.api_doc_source,
+          position: deprecation.yaml_position,
+        },
+        message: LINT_MESSAGES.malformedDeprecationHeader,
+      },
+    ];
+  }
+
+  const code = Number(match[1]);
+
+  return code === expectedCode
+    ? []
+    : [
+        {
+          level: 'error',
+          location: {
+            path: deprecation.api_doc_source,
+            position: deprecation.yaml_position,
+          },
+          message: LINT_MESSAGES.outOfOrderDeprecationCode
+            .replaceAll('{{code}}', match[1])
+            .replace('{{expectedCode}}', `${expectedCode}`.padStart(4, '0')),
+        },
+      ];
+}
+
+/**
+ * Checks if any deprecation codes are out of order
+ *
+ * @type {import('../types').LintRule}
+ */
+export const deprecationCodeOrder = (entries, declarations) => {
+  if (entries.length === 0 || entries[0].api !== 'deprecations') {
+    // This is only relevant to doc/api/deprecations.md
+    return [];
+  }
+
+  const issues = [];
+
+  const hierarchy = buildHierarchy(entries);
+
+  hierarchy.forEach(root => {
+    const deprecations = getDeprecationEntries(root.hierarchyChildren);
+
+    let expectedCode = 1;
+
+    for (const deprecation of deprecations || []) {
+      while (declarations.skipDeprecation.includes(expectedCode)) {
+        expectedCode++;
+      }
+
+      issues.push(...lintDeprecation(deprecation, expectedCode));
+
+      expectedCode++;
+    }
+  });
+
+  return issues;
+};

--- a/src/linter/rules/index.mjs
+++ b/src/linter/rules/index.mjs
@@ -1,5 +1,6 @@
 'use strict';
 
+import { deprecationCodeOrder } from './deprecation-code-order.mjs';
 import { invalidChangeVersion } from './invalid-change-version.mjs';
 import { missingChangeVersion } from './missing-change-version.mjs';
 import { missingIntroducedIn } from './missing-introduced-in.mjs';
@@ -11,4 +12,5 @@ export default {
   'invalid-change-version': invalidChangeVersion,
   'missing-change-version': missingChangeVersion,
   'missing-introduced-in': missingIntroducedIn,
+  'deprecation-code-order': deprecationCodeOrder,
 };

--- a/src/linter/rules/invalid-change-version.mjs
+++ b/src/linter/rules/invalid-change-version.mjs
@@ -1,3 +1,5 @@
+'use strict';
+
 import { LINT_MESSAGES } from '../../constants.mjs';
 import { valid } from 'semver';
 

--- a/src/linter/rules/missing-change-version.mjs
+++ b/src/linter/rules/missing-change-version.mjs
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Checks if any change version is missing
  *

--- a/src/linter/rules/missing-introduced-in.mjs
+++ b/src/linter/rules/missing-introduced-in.mjs
@@ -1,3 +1,5 @@
+'use strict';
+
 import { LINT_MESSAGES } from '../../constants.mjs';
 
 /**

--- a/src/linter/rules/utils/getDeprecationEntries.mjs
+++ b/src/linter/rules/utils/getDeprecationEntries.mjs
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * @param {Array<import('../../../generators/legacy-json/types').HierarchizedEntry>} hierarchy
+ * @returns {Array<import('../../../generators/legacy-json/types').HierarchizedEntry> | undefined}
+ */
+export default function getDeprecationEntries(hierarchy) {
+  for (const child of hierarchy) {
+    if (child.slug === 'list-of-deprecated-apis') {
+      return child.hierarchyChildren;
+    }
+  }
+
+  return undefined;
+}

--- a/src/linter/types.d.ts
+++ b/src/linter/types.d.ts
@@ -13,6 +13,13 @@ export interface LintIssue {
   location: LintIssueLocation;
 }
 
-type LintRule = (input: ApiDocMetadataEntry) => LintIssue[];
+export interface LintDeclarations {
+  skipDeprecation: Array<number>;
+}
+
+type LintRule = (
+  input: Array<ApiDocMetadataEntry>,
+  declarations: LintDeclarations
+) => LintIssue[];
 
 export type Reporter = (msg: LintIssue) => void;

--- a/src/queries.mjs
+++ b/src/queries.mjs
@@ -200,6 +200,8 @@ createQueries.QUERIES = {
   stabilityIndexPrefix: /Stability: ([0-5])/,
   // ReGeX for retrieving the inner content from a YAML block
   yamlInnerContent: /^<!--[ ]?(?:YAML([\s\S]*?)|([ \S]*?))?[ ]?-->/,
+  // ReGeX for retrieiving inline linting directives
+  linterComment: /^<!--[ ]?md-lint (.+?)[ ]?-->$/,
 };
 
 createQueries.UNIST = {
@@ -216,6 +218,12 @@ createQueries.UNIST = {
    */
   isYamlNode: ({ type, value }) =>
     type === 'html' && createQueries.QUERIES.yamlInnerContent.test(value),
+  /**
+   * @param {import('@types/mdast').Html} html
+   * @returns {boolean}
+   */
+  isLinterComment: ({ type, value }) =>
+    type === 'html' && createQueries.QUERIES.linterComment.test(value),
   /**
    * @param {import('@types/mdast').Text} text
    * @returns {boolean}

--- a/src/utils/buildHierarchy.mjs
+++ b/src/utils/buildHierarchy.mjs
@@ -1,10 +1,12 @@
+'use strict';
+
 /**
  * Recursively finds the most suitable parent entry for a given `entry` based on heading depth.
  *
  * @param {ApiDocMetadataEntry} entry
  * @param {ApiDocMetadataEntry[]} entries
  * @param {number} startIdx
- * @returns {import('../types.d.ts').HierarchizedEntry}
+ * @returns {import('../generators/legacy-json/types').HierarchizedEntry}
  */
 function findParent(entry, entries, startIdx) {
   // Base case: if we're at the beginning of the list, no valid parent exists.
@@ -44,7 +46,7 @@ function findParent(entry, entries, startIdx) {
  * current index - 1.
  *
  * @param {Array<ApiDocMetadataEntry>} entries
- * @returns {Array<import('../types.d.ts').HierarchizedEntry>}
+ * @returns {Array<import('../generators/legacy-json/types').HierarchizedEntry>}
  */
 export function buildHierarchy(entries) {
   const roots = [];


### PR DESCRIPTION
Adds a check to the linter that ensures all of the deprecation codes in `doc/api/deprecations.md` are in numerical order.

This also required adding linting declarations to the linter (i.e. `<!-- md-lint ... -->`), since some of the missing deprecations are ignored for whatever reason.

TODO:
- [ ] write tests for the check & declarations
- [ ] deprecation type check
- [ ] cleanup