### PR TITLE
refactor: remove mustache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "hastscript": "^9.0.1",
         "lightningcss": "^1.30.1",
         "mdast-util-slice-markdown": "^2.0.1",
-        "mustache": "^4.2.0",
         "preact": "^10.26.9",
         "preact-render-to-string": "^6.5.13",
         "reading-time": "^1.5.0",
@@ -7986,15 +7985,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
     },
     "node_modules/nano-spawn": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:update-snapshots": "node --test --experimental-test-module-mocks --test-update-snapshots",
     "test:watch": "node --test --experimental-test-module-mocks --watch",
     "prepare": "husky",
-    "run": "node bin/cli.mjs",
+    "run": "node --inspect bin/cli.mjs ",
     "watch": "node --watch bin/cli.mjs"
   },
   "main": "./src/index.mjs",
@@ -60,7 +60,6 @@
     "hastscript": "^9.0.1",
     "lightningcss": "^1.30.1",
     "mdast-util-slice-markdown": "^2.0.1",
-    "mustache": "^4.2.0",
     "preact": "^10.26.9",
     "preact-render-to-string": "^6.5.13",
     "reading-time": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:update-snapshots": "node --test --experimental-test-module-mocks --test-update-snapshots",
     "test:watch": "node --test --experimental-test-module-mocks --watch",
     "prepare": "husky",
-    "run": "node --inspect bin/cli.mjs ",
+    "run": "node bin/cli.mjs ",
     "watch": "node --watch bin/cli.mjs"
   },
   "main": "./src/index.mjs",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:update-snapshots": "node --test --experimental-test-module-mocks --test-update-snapshots",
     "test:watch": "node --test --experimental-test-module-mocks --watch",
     "prepare": "husky",
-    "run": "node bin/cli.mjs ",
+    "run": "node bin/cli.mjs",
     "watch": "node --watch bin/cli.mjs"
   },
   "main": "./src/index.mjs",

--- a/src/generators/web/template.html
+++ b/src/generators/web/template.html
@@ -19,5 +19,6 @@
 
 <body>
   <div id="root">{{dehydrated}}</div>
-
-
+  <script>{{clientBundleJs}}</script>
+</body>
+</html>

--- a/src/generators/web/template.html
+++ b/src/generators/web/template.html
@@ -18,8 +18,6 @@
 </head>
 
 <body>
-  <div id="root">{{{dehydrated}}}</div>
-  <script>{{{javascript}}}</script>
-</body>
+  <div id="root">{{dehydrated}}</div>
 
-</html>
+

--- a/src/generators/web/utils/processing.mjs
+++ b/src/generators/web/utils/processing.mjs
@@ -73,16 +73,11 @@ export async function processJSXEntry(
 
   const title = `${entry.data.heading.data.name} | Node.js v${version} Documentation`;
 
-  const scriptTag = `<script>${clientBundle.js}</script>`;
-
   // Replace template placeholders with actual content
-  const filledTemplate = template
+  const renderedHtml = template
     .replace('{{title}}', title)
-    .replace('{{dehydrated}}', dehydrated ?? '');
-
-  const renderedHtml = `${filledTemplate}
-${scriptTag}
-</body></html>`;
+    .replace('{{dehydrated}}', dehydrated ?? '')
+    .replace('{{clientBundleJs}}', () => clientBundle.js);
 
   // The input to `minify` must be a Buffer.
   const finalHTMLBuffer = HTMLMinifier.minify(Buffer.from(renderedHtml), {});

--- a/src/generators/web/utils/processing.mjs
+++ b/src/generators/web/utils/processing.mjs
@@ -1,6 +1,5 @@
 import HTMLMinifier from '@minify-html/node';
 import { toJs, jsx } from 'estree-util-to-js';
-import Mustache from 'mustache';
 
 import bundleCode from './bundle.mjs';
 
@@ -72,12 +71,18 @@ export async function processJSXEntry(
   const clientCode = buildClientProgram(code);
   const clientBundle = await bundleCode(clientCode);
 
-  // TODO(@avivkeller): Don't depend on Mustache
-  const renderedHtml = Mustache.render(template, {
-    title: `${entry.data.heading.data.name} | Node.js v${version} Documentation`,
-    dehydrated,
-    javascript: clientBundle.js,
-  });
+  const title = `${entry.data.heading.data.name} | Node.js v${version} Documentation`;
+
+  const scriptTag = `<script>${clientBundle.js}</script>`;
+
+  // Replace template placeholders with actual content
+  const filledTemplate = template
+    .replace('{{title}}', title)
+    .replace('{{dehydrated}}', dehydrated ?? '');
+
+  const renderedHtml = `${filledTemplate}
+${scriptTag}
+</body></html>`;
 
   // The input to `minify` must be a Buffer.
   const finalHTMLBuffer = HTMLMinifier.minify(Buffer.from(renderedHtml), {});


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Remove the mustache dep. I can't understand why replacing the script didn't work, the template gets rendered multiple times. but concatenation works 🤔

## Validation

```
npx doc-kit generate -i doc/api/*.md -t web -o out/
```

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
