### PR TITLE
fix(win): use windows-safe paths

### DIFF
--- a/src/generators/web/constants.mjs
+++ b/src/generators/web/constants.mjs
@@ -1,3 +1,17 @@
+import { parse, relative, sep, dirname } from 'node:path';
+import { resolve } from 'node:path/posix';
+import { fileURLToPath } from 'node:url';
+
+// Convert the current module's URL to a filesystem path,
+// then calculate the relative path from the system root directory
+// to this file. This relative path uses platform-specific separators,
+// so replace them with forward slashes ("/") for consistency and web compatibility.
+// Finally, prepend a leading slash to form an absolute root-relative path string.
+//
+// This produces a POSIX-style absolute path, even on Windows systems.
+const dir = dirname(fileURLToPath(import.meta.url));
+export const ROOT = '/' + relative(parse(dir).root, dir).replaceAll(sep, '/');
+
 /**
  * @typedef {Object} JSXImportConfig
  * @property {string} name - The name of the component to be imported.
@@ -12,19 +26,19 @@
 export const JSX_IMPORTS = {
   NavBar: {
     name: 'NavBar',
-    source: new URL('./ui/components/NavBar', import.meta.url).pathname,
+    source: resolve(ROOT, './ui/components/NavBar'),
   },
   SideBar: {
     name: 'SideBar',
-    source: new URL('./ui/components/SideBar', import.meta.url).pathname,
+    source: resolve(ROOT, './ui/components/SideBar'),
   },
   MetaBar: {
     name: 'MetaBar',
-    source: new URL('./ui/components/MetaBar', import.meta.url).pathname,
+    source: resolve(ROOT, './ui/components/MetaBar'),
   },
   CodeBox: {
     name: 'CodeBox',
-    source: new URL('./ui/components/CodeBox', import.meta.url).pathname,
+    source: resolve(ROOT, './ui/components/CodeBox'),
   },
   CodeTabs: {
     name: 'CodeTabs',

--- a/src/generators/web/utils/bundle.mjs
+++ b/src/generators/web/utils/bundle.mjs
@@ -37,7 +37,9 @@ export default async function bundleCode(code, { server = false } = {}) {
     // External dependencies to exclude from bundling.
     // These are expected to be available at runtime in the server environment.
     // This reduces bundle size and avoids bundling shared server libs.
-    external: server ? ['preact', '@node-core/ui-components'] : [],
+    external: server
+      ? ['preact', 'preact-render-to-string', '@node-core/ui-components']
+      : [],
 
     // Inject global compile-time constants that will be replaced in code.
     // These are useful for tree-shaking and conditional branching.

--- a/src/generators/web/utils/generate.mjs
+++ b/src/generators/web/utils/generate.mjs
@@ -1,4 +1,6 @@
-import { JSX_IMPORTS } from '../constants.mjs';
+import { resolve } from 'node:path/posix';
+
+import { JSX_IMPORTS, ROOT } from '../constants.mjs';
 
 /**
  * Creates an ES Module `import` statement as a string, based on parameters.
@@ -54,43 +56,35 @@ export default () => {
       // Import client-side CSS styles.
       // This ensures that styles used in the rendered app are loaded on the client.
       // The use of `new URL(...).pathname` resolves the absolute path for `entrypoint.jsx`.
-      createImportDeclaration(
-        null,
-        new URL('../ui/index.css', import.meta.url).pathname
-      ),
+      createImportDeclaration(null, resolve(ROOT, './ui/index.css')),
 
       // Import `hydrate()` from Preact — needed to attach to server-rendered HTML.
       // This is a named import (not default), hence `false` as the third argument.
       createImportDeclaration('hydrate', 'preact', false),
 
-      '',
-
       // Hydration call: binds the component to an element with ID "root"
       // This assumes SSR has placed matching HTML there, which, it has.
       `hydrate(${componentCode}, document.getElementById("root"));`,
-    ].join('\n');
+    ].join('');
   };
 
   /**
    * Builds a server-side rendering (SSR) program.
    *
    * @param {string} componentCode - Code expression representing a JSX component
+   * @param {string} variable - The variable to output it to
    */
-  const buildServerProgram = componentCode => {
+  const buildServerProgram = (componentCode, variable) => {
     return [
       // JSX component imports
       ...baseImports,
 
-      // Import `renderToStringAsync()` from Preact's SSR module
-      createImportDeclaration(
-        'renderToStringAsync',
-        'preact-render-to-string',
-        false
-      ),
+      // Import Preact's SSR module
+      createImportDeclaration('render', 'preact-render-to-string', false),
 
       // Render the component to an HTML string
       // The output can be embedded directly into the server's HTML template
-      `const code = renderToStringAsync(${componentCode});`,
+      `const ${variable} = render(${componentCode});`,
     ].join('\n');
   };
 


### PR DESCRIPTION
Currently, `doc-kit` does not work on Windows due to a Rolldown issue, and a paths issue.

This PR fixes the paths issue by using Windows-safe paths.

Additionally,
- When not minified, there is a chance that the code will end with an `//#endregion` comment. We need to add a newline before the `return`
- We set the variable `code =` to to dehydration, not our generated variable. TBH, I'm not sure how this worked at all previously...

@TheAlexLichter There appears to be a bug when building this on Windows:
It appears to import everything twice. Once using a Unix path, and once using a Windows path.