### PR TITLE
fix(win): use windows-safe paths correctly

### DIFF
--- a/src/generators/web/constants.mjs
+++ b/src/generators/web/constants.mjs
@@ -1,16 +1,17 @@
-import { parse, relative, sep, dirname } from 'node:path';
-import { resolve } from 'node:path/posix';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Convert the current module's URL to a filesystem path,
-// then calculate the relative path from the system root directory
-// to this file. This relative path uses platform-specific separators,
-// so replace them with forward slashes ("/") for consistency and web compatibility.
-// Finally, prepend a leading slash to form an absolute root-relative path string.
-//
-// This produces a POSIX-style absolute path, even on Windows systems.
-const dir = dirname(fileURLToPath(import.meta.url));
-export const ROOT = '/' + relative(parse(dir).root, dir).replaceAll(sep, '/');
+export const ROOT = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Converts a filesystem path to POSIX-style format on non-POSIX platforms.
+ *
+ * @param {string} path - The original file path.
+ * @returns {string} The normalized path using POSIX-style separators if applicable.
+ */
+export const toPosixPath = path => {
+  return process.platform === 'win32' ? path.replaceAll('\\', '/') : path;
+};
 
 /**
  * @typedef {Object} JSXImportConfig
@@ -26,19 +27,19 @@ export const ROOT = '/' + relative(parse(dir).root, dir).replaceAll(sep, '/');
 export const JSX_IMPORTS = {
   NavBar: {
     name: 'NavBar',
-    source: resolve(ROOT, './ui/components/NavBar'),
+    source: toPosixPath(resolve(ROOT, './ui/components/NavBar')),
   },
   SideBar: {
     name: 'SideBar',
-    source: resolve(ROOT, './ui/components/SideBar'),
+    source: toPosixPath(resolve(ROOT, './ui/components/SideBar')),
   },
   MetaBar: {
     name: 'MetaBar',
-    source: resolve(ROOT, './ui/components/MetaBar'),
+    source: toPosixPath(resolve(ROOT, './ui/components/MetaBar')),
   },
   CodeBox: {
     name: 'CodeBox',
-    source: resolve(ROOT, './ui/components/CodeBox'),
+    source: toPosixPath(resolve(ROOT, './ui/components/CodeBox')),
   },
   CodeTabs: {
     name: 'CodeTabs',

--- a/src/generators/web/utils/generate.mjs
+++ b/src/generators/web/utils/generate.mjs
@@ -1,6 +1,6 @@
-import { resolve } from 'node:path/posix';
+import { resolve } from 'node:path';
 
-import { JSX_IMPORTS, ROOT } from '../constants.mjs';
+import { JSX_IMPORTS, ROOT, toPosixPath } from '../constants.mjs';
 
 /**
  * Creates an ES Module `import` statement as a string, based on parameters.
@@ -56,7 +56,10 @@ export default () => {
       // Import client-side CSS styles.
       // This ensures that styles used in the rendered app are loaded on the client.
       // The use of `new URL(...).pathname` resolves the absolute path for `entrypoint.jsx`.
-      createImportDeclaration(null, resolve(ROOT, './ui/index.css')),
+      createImportDeclaration(
+        null,
+        toPosixPath(resolve(ROOT, './ui/index.css'))
+      ),
 
       // Import `hydrate()` from Preact — needed to attach to server-rendered HTML.
       // This is a named import (not default), hence `false` as the third argument.


### PR DESCRIPTION
## Description

Let me briefly explain where the issue lies.

### Even when we use Windows-style paths, it still breaks.

The root cause is the following code: https://github.com/shulaoda/doc-kit/blob/10869bf6b60c1a41ebc188516c7d6a631d4dfef5/src/generators/web/utils/generate.mjs#L51-L72

```js
[
  'import NavBar from "D:\\shulaoda\\doc-kit\\src\\generators\\web\\ui\\components\\NavBar";',
  'import SideBar from "D:\\shulaoda\\doc-kit\\src\\generators\\web\\ui\\components\\SideBar";',
].join('')
```
After joining the strings, the `\\` sequences are interpreted as single backslashes (`\`), resulting in:

```js
'import NavBar from "D:\shulaoda\doc-kit\src\generators\web\ui\components\NavBar";import SideBar from "D:\shulaoda\doc-kit\src\generators\web\ui\components\SideBar";'
```
This causes the bundler to fail because the backslashes are treated either as escape characters or as invalid syntax.

### Why we need `toPosixPath`
There’s a problem with how we currently handled Windows paths. When `ROOT` is something like `D:/shulaoda/doc-kit/src/generators/web`, using `path.posix.resolve(ROOT, './ui/components/NavBar')` results in:

```shell
/shulaoda/doc-kit/D:/shulaoda/doc-kit/src/generators/web/ui/components/NavBar
```
This happens because `path.posix` doesn’t understand the `D:/` drive prefix — it treats it as a normal directory name and incorrectly prepends the current working directory (`/shulaoda/doc-kit`) to it.


## Validation

I verified it locally on my Windows.

## Related Issues

closes https://github.com/rolldown/rolldown/issues/5364

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
