### PR TITLE
fix(win): include drive letter

### DIFF
--- a/src/generators/web/constants.mjs
+++ b/src/generators/web/constants.mjs
@@ -1,16 +1,7 @@
-import { parse, relative, sep, dirname } from 'node:path';
-import { resolve } from 'node:path/posix';
+import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Convert the current module's URL to a filesystem path,
-// then calculate the relative path from the system root directory
-// to this file. This relative path uses platform-specific separators,
-// so replace them with forward slashes ("/") for consistency and web compatibility.
-// Finally, prepend a leading slash to form an absolute root-relative path string.
-//
-// This produces a POSIX-style absolute path, even on Windows systems.
-const dir = dirname(fileURLToPath(import.meta.url));
-export const ROOT = '/' + relative(parse(dir).root, dir).replaceAll(sep, '/');
+export const ROOT = dirname(fileURLToPath(import.meta.url));
 
 /**
  * @typedef {Object} JSXImportConfig
@@ -26,19 +17,19 @@ export const ROOT = '/' + relative(parse(dir).root, dir).replaceAll(sep, '/');
 export const JSX_IMPORTS = {
   NavBar: {
     name: 'NavBar',
-    source: resolve(ROOT, './ui/components/NavBar'),
+    source: resolve(ROOT, './ui/components/NavBar').replaceAll('\\', '\\\\'),
   },
   SideBar: {
     name: 'SideBar',
-    source: resolve(ROOT, './ui/components/SideBar'),
+    source: resolve(ROOT, './ui/components/SideBar').replaceAll('\\', '\\\\'),
   },
   MetaBar: {
     name: 'MetaBar',
-    source: resolve(ROOT, './ui/components/MetaBar'),
+    source: resolve(ROOT, './ui/components/MetaBar').replaceAll('\\', '\\\\'),
   },
   CodeBox: {
     name: 'CodeBox',
-    source: resolve(ROOT, './ui/components/CodeBox'),
+    source: resolve(ROOT, './ui/components/CodeBox').replaceAll('\\', '\\\\'),
   },
   CodeTabs: {
     name: 'CodeTabs',

--- a/src/generators/web/utils/generate.mjs
+++ b/src/generators/web/utils/generate.mjs
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path/posix';
+import { resolve } from 'node:path';
 
 import { JSX_IMPORTS, ROOT } from '../constants.mjs';
 
@@ -56,7 +56,10 @@ export default () => {
       // Import client-side CSS styles.
       // This ensures that styles used in the rendered app are loaded on the client.
       // The use of `new URL(...).pathname` resolves the absolute path for `entrypoint.jsx`.
-      createImportDeclaration(null, resolve(ROOT, './ui/index.css')),
+      createImportDeclaration(
+        null,
+        resolve(ROOT, './ui/index.css').replaceAll('\\', '\\\\')
+      ),
 
       // Import `hydrate()` from Preact — needed to attach to server-rendered HTML.
       // This is a named import (not default), hence `false` as the third argument.


### PR DESCRIPTION
Closes #363
Ref: https://github.com/rolldown/rolldown/issues/5364#issuecomment-3094766944

If we include the drive letters, the resolution will not duplicate imports.