### PR TITLE
feat(web): improve deprecation page

### DIFF
--- a/src/generators/jsx-ast/constants.mjs
+++ b/src/generators/jsx-ast/constants.mjs
@@ -18,6 +18,9 @@ export const TOC_MAX_HEADING_DEPTH = 3;
 // 'Stability: '.length + ' - '.length
 export const STABILITY_PREFIX_LENGTH = 14;
 
+// 'Type: '.length
+export const TYPE_PREFIX_LENGTH = 6;
+
 /**
  * HTML tag to UI component mappings
  */

--- a/src/generators/jsx-ast/utils/buildContent.mjs
+++ b/src/generators/jsx-ast/utils/buildContent.mjs
@@ -178,18 +178,20 @@ export const transformHeadingNode = (entry, remark, node, index, parent) => {
     createChangeElement(entry, remark)
   );
 
-  if (entry.api === 'deprecations') {
+  if (entry.api === 'deprecations' && node.depth === 3) {
     // On the 'deprecations.md' page, "Type: <XYZ>" turns into an AlertBox
-    const typeNode = parent.children[index + 1];
-    if (typeNode) {
-      parent.children[index + 1] = createJSXElement(JSX_IMPORTS.AlertBox.name, {
-        children: slice(typeNode, TYPE_PREFIX_LENGTH, undefined, {
+    parent.children[index + 1] = createJSXElement(JSX_IMPORTS.AlertBox.name, {
+      children: slice(
+        parent.children[index + 1],
+        TYPE_PREFIX_LENGTH,
+        undefined,
+        {
           textHandling: { boundaries: 'preserve' },
-        }).node.children,
-        level: 'danger',
-        title: 'Type',
-      });
-    }
+        }
+      ).node.children,
+      level: 'danger',
+      title: 'Type',
+    });
   }
 
   // Add source link element if available, right after heading

--- a/src/generators/web/ui/index.css
+++ b/src/generators/web/ui/index.css
@@ -12,6 +12,7 @@ main {
   /* Code should inherit its font size */
   code {
     font-size: inherit;
+    font-weight: inherit;
   }
 
   /* Don't overflow the parent */


### PR DESCRIPTION
<img width="720" height="134" alt="image_720" src="https://github.com/user-attachments/assets/e5867c7b-686e-4411-8151-ebc29574ced8" />

Improves the deprecation page by:
1. Not slicing the `DEPXXX:` off the title
2. Not bolding the code blocks, they should inherit their weight
3. Putting the deprecation type inside an AlertBox