### PR TITLE
fix(regexp): re-use common patterns

### DIFF
--- a/src/utils/parser/constants.mjs
+++ b/src/utils/parser/constants.mjs
@@ -18,34 +18,44 @@ export const DOC_MDN_BASE_URL_JS_GLOBALS = `${DOC_MDN_BASE_URL_JS}Reference/Glob
 // These are regular expressions used to determine if a given Markdown heading
 // is a specific type of API Doc entry (e.g., Event, Class, Method, etc)
 // and to extract the inner content of said Heading to be used as the API doc entry name
+const CAMEL_CASE = '\\w+(?:\\.\\w+)*';
+const FUNCTION_CALL = '\\([^)]*\\)';
+
+// Matches "bar":
+// Group 1: foo[bar]
+// Group 2: foo.bar
+const PROPERTY = `${CAMEL_CASE}(?:(\\[${CAMEL_CASE}\\])|\\.(\\w+))`;
+
 export const DOC_API_HEADING_TYPES = [
   {
     type: 'method',
-    regex:
-      // Group 1: foo[bar]()
-      // Group 2: foo.bar()
-      // Group 3: foobar()
-      /^`?(?:\w*(?:(\[[^\]]+\])|(?:\.(\w+)))|(\w+))\([^)]*\)`?$/i,
+    regex: new RegExp(`^\`${PROPERTY}${FUNCTION_CALL}\`?$`, 'i'),
   },
   { type: 'event', regex: /^Event: +`?['"]?([^'"]+)['"]?`?$/i },
   {
     type: 'class',
-    regex:
-      /^Class: +`?([A-Z]\w+(?:\.[A-Z]\w+)*(?: +extends +[A-Z]\w+(?:\.[A-Z]\w+)*)?)`?$/i,
+    regex: new RegExp(
+      `Class: +\`?(${CAMEL_CASE}(?: extends +${CAMEL_CASE})?)\`?$`,
+      'i'
+    ),
   },
   {
     type: 'ctor',
-    regex: /^(?:Constructor: +)?`?new +([A-Z]\w+(?:\.[A-Z]\w+)*)\([^)]*\)`?$/i,
+    regex: new RegExp(
+      `^(?:Constructor: +)?\`?new +(${CAMEL_CASE})${FUNCTION_CALL}\`?$`,
+      'i'
+    ),
   },
   {
     type: 'classMethod',
-    regex:
-      /^Static method: +`?[A-Z]\w+(?:\.[A-Z]\w+)*(?:(\[\w+\.\w+\])|\.(\w+))\([^)]*\)`?$/i,
+    regex: new RegExp(
+      `^Static method: +\`?${PROPERTY}${FUNCTION_CALL}\`?$`,
+      'i'
+    ),
   },
   {
     type: 'property',
-    regex:
-      /^(?:Class property: +)?`?[A-Z]\w+(?:\.[A-Z]\w+)*(?:(\[\w+\.\w+\])|\.(\w+))`?$/i,
+    regex: new RegExp(`^(?:Class property: +)?\`?${PROPERTY}\`?$`, 'i'),
   },
 ];
 

--- a/src/utils/parser/constants.mjs
+++ b/src/utils/parser/constants.mjs
@@ -29,7 +29,7 @@ const PROPERTY = `${CAMEL_CASE}(?:(\\[${CAMEL_CASE}\\])|\\.(\\w+))`;
 export const DOC_API_HEADING_TYPES = [
   {
     type: 'method',
-    regex: new RegExp(`^\`${PROPERTY}${FUNCTION_CALL}\`?$`, 'i'),
+    regex: new RegExp(`^\`?${PROPERTY}${FUNCTION_CALL}\`?$`, 'i'),
   },
   { type: 'event', regex: /^Event: +`?['"]?([^'"]+)['"]?`?$/i },
   {


### PR DESCRIPTION
Broken out of: #366
Fixes: #356

This PR moves the common patterns used by `DOC_API_HEADING_TYPES` into there own RegExps, to prevent de-syncing between the RegExps.