### PR TITLE
feat(metabar): improve headings and add stability

### DIFF
--- a/src/generators/jsx-ast/utils/buildBarProps.mjs
+++ b/src/generators/jsx-ast/utils/buildBarProps.mjs
@@ -41,15 +41,23 @@ const shouldIncludeEntryInToC = ({ heading }) =>
 const extractHeading = entry => {
   const data = entry.heading.data;
 
-  const rawName = data.name
-    // Remove any containing code blocks
-    .replace(/`/g, '')
-    // Remove any prefixes (i.e. 'Class:')
-    .replace(/^[^:]+:/, '')
-    // Trim the remaining whitespace
-    .trim();
+  const cliFlagOrEnv = [...data.text.matchAll(/`(-[\w-]+|[A-Z0-9_]+=)/g)];
 
-  let heading = getFullName(data, rawName);
+  let heading;
+
+  if (cliFlagOrEnv.length > 0) {
+    heading = cliFlagOrEnv.at(-1)[1];
+  } else {
+    const rawName = data.name
+      // Remove any containing code blocks
+      .replace(/`/g, '')
+      // Remove any prefixes (i.e. 'Class:')
+      .replace(/^[^:]+:/, '')
+      // Trim the remaining whitespace
+      .trim();
+
+    heading = getFullName(data, rawName);
+  }
 
   if (data.type === 'ctor') {
     heading += ' Constructor';
@@ -58,6 +66,7 @@ const extractHeading = entry => {
   return {
     depth: entry.heading.depth,
     value: heading,
+    stability: parseInt(entry.stability?.children[0]?.data.index ?? 2),
     slug: data.slug,
   };
 };

--- a/src/generators/web/ui/components/MetaBar/index.jsx
+++ b/src/generators/web/ui/components/MetaBar/index.jsx
@@ -1,4 +1,5 @@
 import { CodeBracketIcon, DocumentIcon } from '@heroicons/react/24/outline';
+import Badge from '@node-core/ui-components/Common/Badge';
 import MetaBar from '@node-core/ui-components/Containers/MetaBar';
 import GitHubIcon from '@node-core/ui-components/Icons/Social/GitHub';
 
@@ -11,12 +12,15 @@ const iconMap = {
 
 /**
  * @typedef MetaBarProps
- * @property {Array<import('@vcarl/remark-headings').Heading>} headings - Array of page headings for table of contents
+ * @property {Array<import('@vcarl/remark-headings').Heading & { stability: string }>} headings - Array of page headings for table of contents
  * @property {string} addedIn - Version or date when feature was added
  * @property {string} readingTime - Estimated reading time for the page
  * @property {Array<[string, string]>} viewAs - Array of [title, path] tuples for view options
  * @property {string} editThisPage - URL for editing the current page
  */
+
+const STABILITY_KINDS = ['error', 'warning', null, 'default'];
+const STABILITY_LABELS = ['D', 'E', null, 'L'];
 
 /**
  * MetaBar component that displays table of contents and page metadata
@@ -32,8 +36,23 @@ export default ({
   <MetaBar
     heading="Table of Contents"
     headings={{
-      items: headings.map(({ slug, ...heading }) => ({
+      items: headings.map(({ slug, value, stability, ...heading }) => ({
         ...heading,
+        value:
+          stability !== 2 ? (
+            <>
+              {value}
+              <Badge
+                size="small"
+                className={styles.badge}
+                kind={STABILITY_KINDS[stability]}
+              >
+                {STABILITY_LABELS[stability]}
+              </Badge>
+            </>
+          ) : (
+            value
+          ),
         data: { id: slug },
       })),
     }}

--- a/src/generators/web/ui/components/MetaBar/index.module.css
+++ b/src/generators/web/ui/components/MetaBar/index.module.css
@@ -4,3 +4,8 @@
   height: 1rem;
   margin-right: 0.25rem;
 }
+
+.badge {
+  display: inline-block;
+  margin-left: 0.25rem;
+}


### PR DESCRIPTION
This PR adds Stability notices to the sidebar ("E" for Experimental, "L" for Legacy, "D" for Deprecated, and nothing for Stable). Additionally, it trims CLI flags and Environment variables down to just their names, similarly to how we do for methods.

<img width="309" height="777" alt="image" src="https://github.com/user-attachments/assets/4f85f3d9-401a-4960-b4f1-50910b810aa9" />
<img width="290" height="643" alt="image" src="https://github.com/user-attachments/assets/5273f64e-7a5b-474c-be36-4b66d8e925c3" />
