### PR TITLE
fix(deps): use exact versions

### DIFF
--- a/.github/workflows/update-internal-dependencies.yml
+++ b/.github/workflows/update-internal-dependencies.yml
@@ -33,7 +33,7 @@ jobs:
               latest=$(npm view "$dep" version)
               echo "Upgrading $dep to $latest"
               # Use jq to update the version in package.json
-              jq --arg section "$section" --arg dep "$dep" --arg ver "^$latest" \
+              jq --arg section "$section" --arg dep "$dep" --arg ver "$latest" \
                 '(.[$section][$dep]) |= $ver' package.json > package.json.tmp && mv package.json.tmp package.json
             done
           done


### PR DESCRIPTION
I'm not sure whether we want to enforce exact versioning with our internal dependencies. 

This can be approved or rejected as we see fit.

Right now, the dependency versions are locked, as they were very volatile during the web generator creation, however, if we unlock them, it'll allow for less update PRs, but higher chance of breaking changes.

This PR will lock the versions to the exact version for our updating workflow. 