### PR TITLE
fix(globals): use `globals` for globals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,6 @@ updates:
           - 'eslint'
           - 'eslint-*'
           - 'lint-staged'
-          - 'globals'
           - '@eslint/*'
       unist:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "estree-util-visit": "^2.0.0",
         "github-slugger": "^2.0.0",
         "glob": "^11.0.3",
+        "globals": "^16.3.0",
         "hast-util-to-string": "^3.0.1",
         "hastscript": "^9.0.1",
         "lightningcss": "^1.30.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "estree-util-visit": "^2.0.0",
     "github-slugger": "^2.0.0",
     "glob": "^11.0.3",
+    "globals": "^16.3.0",
     "hast-util-to-string": "^3.0.1",
     "hastscript": "^9.0.1",
     "lightningcss": "^1.30.1",

--- a/src/utils/parser/__tests__/index.test.mjs
+++ b/src/utils/parser/__tests__/index.test.mjs
@@ -12,7 +12,7 @@ describe('transformTypeToReferenceLink', () => {
   it('should transform a JavaScript primitive type into a Markdown link', () => {
     strictEqual(
       transformTypeToReferenceLink('string'),
-      '[`<string>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)'
+      '[`<string>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type)'
     );
   });
 

--- a/src/utils/parser/constants.mjs
+++ b/src/utils/parser/constants.mjs
@@ -72,15 +72,20 @@ export const DOC_API_HEADING_TYPES = [
 // This is a mapping for types within the Markdown content and their respective
 // JavaScript primitive types within the MDN JavaScript docs
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Data_structures#primitive_values
-export const DOC_TYPES_MAPPING_PRIMITIVES = [
-  'null',
-  'undefined',
-  'boolean',
-  'number',
-  'bigint',
-  'string',
-  'symbol',
-];
+export const DOC_TYPES_MAPPING_PRIMITIVES = {
+  ...Object.fromEntries(
+    [
+      'null',
+      'undefined',
+      'boolean',
+      'number',
+      'bigint',
+      'string',
+      'symbol',
+    ].map(e => [e, e])
+  ),
+  integer: 'number',
+};
 
 // This is a mapping for types within the Markdown content and their respective
 // JavaScript globals types within the MDN JavaScript docs

--- a/src/utils/parser/constants.mjs
+++ b/src/utils/parser/constants.mjs
@@ -1,4 +1,4 @@
-'use strict';
+import globals from 'globals';
 
 // These are string replacements specific to Node.js API docs for anchor IDs
 export const DOC_API_SLUGS_REPLACEMENTS = [
@@ -71,16 +71,16 @@ export const DOC_API_HEADING_TYPES = [
 
 // This is a mapping for types within the Markdown content and their respective
 // JavaScript primitive types within the MDN JavaScript docs
-// @see DOC_MDN_BASE_URL_JS_PRIMITIVES
-export const DOC_TYPES_MAPPING_PRIMITIVES = {
-  boolean: 'Boolean',
-  integer: 'Number', // Not a primitive, used for clarification.
-  null: 'Null',
-  number: 'Number',
-  string: 'String',
-  symbol: 'Symbol',
-  undefined: 'Undefined',
-};
+// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Data_structures#primitive_values
+export const DOC_TYPES_MAPPING_PRIMITIVES = [
+  'null',
+  'undefined',
+  'boolean',
+  'number',
+  'bigint',
+  'string',
+  'symbol',
+];
 
 // This is a mapping for types within the Markdown content and their respective
 // JavaScript globals types within the MDN JavaScript docs
@@ -88,45 +88,15 @@ export const DOC_TYPES_MAPPING_PRIMITIVES = {
 export const DOC_TYPES_MAPPING_GLOBALS = {
   ...Object.fromEntries(
     [
-      'AggregateError',
-      'Array',
-      'ArrayBuffer',
-      'DataView',
-      'Date',
-      'Error',
-      'EvalError',
-      'Function',
-      'Map',
-      'NaN',
-      'Object',
-      'Promise',
-      'Proxy',
-      'RangeError',
-      'ReferenceError',
-      'RegExp',
-      'Set',
-      'SharedArrayBuffer',
-      'SyntaxError',
-      'Symbol',
-      'TypeError',
-      'URIError',
-      'WeakMap',
-      'WeakSet',
-
-      'TypedArray',
-      'Float16Array',
-      'Float32Array',
-      'Float64Array',
-      'Int8Array',
-      'Int16Array',
-      'Int32Array',
-      'Uint8Array',
-      'Uint8ClampedArray',
-      'Uint16Array',
-      'Uint32Array',
+      // This is updated with every ES-spec, so, as long as the
+      // `globals` package is up-to-date, so will our globals
+      // list.
+      ...Object.keys(globals.builtin),
+      'AsyncGeneratorFunction',
+      'AsyncIterator',
+      'AsyncFunction',
     ].map(e => [e, e])
   ),
-  bigint: 'BigInt',
   'WebAssembly.Instance': 'WebAssembly/Instance',
 };
 
@@ -331,18 +301,12 @@ export const DOC_TYPES_MAPPING_OTHER = {
 
   ArrayBufferView: `${DOC_MDN_BASE_URL}/API/ArrayBufferView`,
 
-  AsyncIterator: 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
   AsyncIterable: 'https://tc39.github.io/ecma262/#sec-asynciterable-interface',
-  AsyncFunction: 'https://tc39.es/ecma262/#sec-async-function-constructor',
 
   'Module Namespace Object':
     'https://tc39.github.io/ecma262/#sec-module-namespace-exotic-objects',
 
-  AsyncGeneratorFunction:
-    'https://tc39.es/proposal-async-iteration/#sec-asyncgeneratorfunction-constructor',
-
   Iterable: `${DOC_MDN_BASE_URL_JS}Reference/Iteration_protocols#The_iterable_protocol`,
-  Iterator: `${DOC_MDN_BASE_URL_JS}Reference/Iteration_protocols#The_iterator_protocol`,
 
   CloseEvent: `${DOC_MDN_BASE_URL}/API/CloseEvent`,
   EventSource: `${DOC_MDN_BASE_URL}/API/EventSource`,

--- a/src/utils/parser/index.mjs
+++ b/src/utils/parser/index.mjs
@@ -81,7 +81,7 @@ export const transformTypeToReferenceLink = type => {
    */
   const transformType = lookupPiece => {
     // Transform JS primitive type references into Markdown links (MDN)
-    if (lookupPiece.toLowerCase() in DOC_TYPES_MAPPING_PRIMITIVES) {
+    if (DOC_TYPES_MAPPING_PRIMITIVES.includes(lookupPiece.toLowerCase())) {
       return `${DOC_MDN_BASE_URL_JS_PRIMITIVES}#${lookupPiece.toLowerCase()}_type`;
     }
 

--- a/src/utils/parser/index.mjs
+++ b/src/utils/parser/index.mjs
@@ -82,9 +82,7 @@ export const transformTypeToReferenceLink = type => {
   const transformType = lookupPiece => {
     // Transform JS primitive type references into Markdown links (MDN)
     if (lookupPiece.toLowerCase() in DOC_TYPES_MAPPING_PRIMITIVES) {
-      const typeValue = DOC_TYPES_MAPPING_PRIMITIVES[lookupPiece.toLowerCase()];
-
-      return `${DOC_MDN_BASE_URL_JS_PRIMITIVES}#${typeValue}_type`;
+      return `${DOC_MDN_BASE_URL_JS_PRIMITIVES}#${lookupPiece.toLowerCase()}_type`;
     }
 
     // Transforms JS Global type references into Markdown links (MDN)

--- a/src/utils/parser/index.mjs
+++ b/src/utils/parser/index.mjs
@@ -81,8 +81,10 @@ export const transformTypeToReferenceLink = type => {
    */
   const transformType = lookupPiece => {
     // Transform JS primitive type references into Markdown links (MDN)
-    if (DOC_TYPES_MAPPING_PRIMITIVES.includes(lookupPiece.toLowerCase())) {
-      return `${DOC_MDN_BASE_URL_JS_PRIMITIVES}#${lookupPiece.toLowerCase()}_type`;
+    if (lookupPiece.toLowerCase() in DOC_TYPES_MAPPING_PRIMITIVES) {
+      const typeValue = DOC_TYPES_MAPPING_PRIMITIVES[lookupPiece.toLowerCase()];
+
+      return `${DOC_MDN_BASE_URL_JS_PRIMITIVES}#${typeValue}_type`;
     }
 
     // Transforms JS Global type references into Markdown links (MDN)


### PR DESCRIPTION
## Description

The `globals` library is updated with every builtin global every month (https://github.com/sindresorhus/globals/blob/main/.github/workflows/update.yml), so we can safely rely on it to populate our builtin globals.

IMO this is a safer alternative than having us manually update this list.

## Related Issues

Ref #319
