### PR TITLE
chore(ci): add `web` to generation matrix

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -34,6 +34,8 @@ jobs:
             input: './node/doc/api/*.md'
           - target: legacy-html
             input: './node/doc/api/*.md'
+          - target: web
+            input: './node/doc/api/*.md'
           - target: llms-txt
             input: './node/doc/api/*.md'
       fail-fast: false


### PR DESCRIPTION
Fixes https://github.com/nodejs/doc-kit/issues/396