### PR TITLE
fix(globals): add `ErrorEvent` and `TypedArray`

### DIFF
--- a/src/utils/parser/constants.mjs
+++ b/src/utils/parser/constants.mjs
@@ -100,6 +100,8 @@ export const DOC_TYPES_MAPPING_GLOBALS = {
       'AsyncGeneratorFunction',
       'AsyncIterator',
       'AsyncFunction',
+      'TypedArray',
+      'ErrorEvent',
     ].map(e => [e, e])
   ),
   'WebAssembly.Instance': 'WebAssembly/Instance',


### PR DESCRIPTION
These are missing from our list of globals (I didn't realize `globals.builtin` didn't include them in 0ecb11e818083a87d3eee8df519650760fb0dfe4)