### PR TITLE
fix: add `@actions/core` as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@nodejs/doc-kit",
       "dependencies": {
+        "@actions/core": "^1.11.1",
         "@clack/prompts": "^0.11.0",
         "@heroicons/react": "^2.2.0",
         "@minify-html/node": "^0.16.4",
@@ -74,7 +75,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/exec": "^1.1.1",
@@ -85,7 +85,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
       "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/io": "^1.0.1"
@@ -95,7 +94,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
@@ -106,7 +104,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -460,7 +457,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -8671,7 +8667,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -8726,7 +8721,6 @@
       "version": "5.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
       "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prettier": "3.6.2"
   },
   "dependencies": {
+    "@actions/core": "^1.11.1",
     "@clack/prompts": "^0.11.0",
     "@heroicons/react": "^2.2.0",
     "@minify-html/node": "^0.16.4",


### PR DESCRIPTION
`@actions/core` is used in the GitHub logger transport despite not actually being installed directly, meaning it's only available when `@reporters/github` is downloaded w/ dev dependencies. In Node core we don't install dev dependencies causing this to throw.

<img width="1226" height="273" alt="image" src="https://github.com/user-attachments/assets/d86d49ea-736d-46c7-b707-9c5d2168415f" />
