### PR TITLE
fix(metadata): strip directory prefix when converting nested .md link to .html

### DIFF
--- a/src/generators/metadata/utils/__tests__/parse.test.mjs
+++ b/src/generators/metadata/utils/__tests__/parse.test.mjs
@@ -220,6 +220,34 @@ describe('parseApiDoc', () => {
 
       assert.strictEqual(findLink(entry)?.url, 'events.html#some-section');
     });
+
+    it('strips subdirectory prefix from nested .md links', () => {
+      const tree = u('root', [
+        h('fs'),
+        u('paragraph', [
+          u('link', { url: 'namespaces/comparators.md' }, [
+            u('text', 'comparators'),
+          ]),
+        ]),
+      ]);
+      const [entry] = parseApiDoc({ path, tree }, typeMap);
+
+      assert.strictEqual(findLink(entry)?.url, 'comparators.html');
+    });
+
+    it('strips subdirectory prefix and preserves hash fragments', () => {
+      const tree = u('root', [
+        h('fs'),
+        u('paragraph', [
+          u('link', { url: 'namespaces/comparators.md#some-section' }, [
+            u('text', 'comparators'),
+          ]),
+        ]),
+      ]);
+      const [entry] = parseApiDoc({ path, tree }, typeMap);
+
+      assert.strictEqual(findLink(entry)?.url, 'comparators.html#some-section');
+    });
   });
 
   describe('document without headings', () => {

--- a/src/generators/metadata/utils/__tests__/parse.test.mjs
+++ b/src/generators/metadata/utils/__tests__/parse.test.mjs
@@ -248,6 +248,29 @@ describe('parseApiDoc', () => {
 
       assert.strictEqual(findLink(entry)?.url, 'comparators.html#some-section');
     });
+
+    it('ignores .md full URLs with any protocol', () => {
+      const protocolLinks = [
+        'https://github.com/example/config.md',
+        'http://internal-server.com/docs.md',
+        'file:///C:/Shared/docs/readme.md',
+      ];
+
+      for (const url of protocolLinks) {
+        const tree = u('root', [
+          h('fs'),
+          u('paragraph', [u('link', { url }, [u('text', 'external link')])]),
+        ]);
+        const [entry] = parseApiDoc({ path, tree }, typeMap);
+
+        // Assert that the URL comes out exactly as it went in
+        assert.strictEqual(
+          findLink(entry)?.url,
+          url,
+          `Failed to ignore protocol: ${url}`
+        );
+      }
+    });
   });
 
   describe('document without headings', () => {

--- a/src/generators/metadata/utils/visitors.mjs
+++ b/src/generators/metadata/utils/visitors.mjs
@@ -1,4 +1,5 @@
 'use strict';
+import { basename } from 'node:path/posix';
 
 import { SKIP } from 'unist-util-visit';
 
@@ -18,7 +19,7 @@ import { transformNodesToString } from '../../../utils/unist.mjs';
 export const visitMarkdownLink = node => {
   node.url = node.url.replace(
     QUERIES.markdownUrl,
-    (_, filename, hash = '') => `${filename}.html${hash}`
+    (_, filename, hash = '') => `${basename(filename)}.html${hash}`
   );
 
   return [SKIP];

--- a/src/generators/metadata/utils/visitors.mjs
+++ b/src/generators/metadata/utils/visitors.mjs
@@ -17,6 +17,10 @@ import { transformNodesToString } from '../../../utils/unist.mjs';
  * @param {import('@types/mdast').Link} node A Markdown link node
  */
 export const visitMarkdownLink = node => {
+  // REJECT PROTOCOLS: Catches http:, https:, mailto:, ftp:, file:, vscode:, etc.
+  if (/^[a-z]+:/i.test(node.url)) {
+    return [SKIP];
+  }
   node.url = node.url.replace(
     QUERIES.markdownUrl,
     (_, filename, hash = '') => `${basename(filename)}.html${hash}`


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/api-docs-tooling/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
This PR reinforce the link conversion logic for nested .md files by stripping the directory prefix.

<!-- Write a brief description of the changes introduced by this PR -->

## Validation
### before : 
[Screencast from 2026-04-14 05-00-18.webm](https://github.com/user-attachments/assets/439fab65-fe86-444b-addb-73301053f48b)

### after : 
[Screencast from 2026-04-14 04-36-15.webm](https://github.com/user-attachments/assets/d408d857-14eb-4290-97cf-5febec857dab)


<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues
n/a

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/api-docs-tooling/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
