### PR TITLE
fix(react): avoid clipped stability tooltips

### DIFF
--- a/.changeset/fix-metabar-stability-tooltip.md
+++ b/.changeset/fix-metabar-stability-tooltip.md
@@ -1,0 +1,6 @@
+---
+'@doc-kit/generator-react': patch
+---
+
+Prevent stability badge tooltips in the meta bar from being clipped by the
+scrolling table of contents.

--- a/packages/react/src/html/__tests__/generate.test.mjs
+++ b/packages/react/src/html/__tests__/generate.test.mjs
@@ -70,9 +70,12 @@ describe('web generate', () => {
     const { output } = await createTestConfiguration(context);
     const fs = createEntry('fs', 'File system');
     fs.path = '/api/fs';
+    const experimental = createEntry('experimental', 'Experimental API');
+    experimental.heading.depth = 2;
+    experimental.stability = { data: { index: '1' } };
     const notFoundPage = buildNotFoundPage();
     const contents = await Promise.all([
-      buildContent([fs], fs),
+      buildContent([fs, experimental], fs),
       buildContent(notFoundPage.entries, notFoundPage.head),
     ]);
 
@@ -86,6 +89,8 @@ describe('web generate', () => {
     assert.match(fsHTML, /View As/);
     assert.match(fsHTML, /href=fs\.json/);
     assert.match(fsHTML, /href=fs\.md/);
+    assert.match(fsHTML, /title=Experimental/);
+    assert.doesNotMatch(fsHTML, /data-tooltip=Experimental/);
     assert.doesNotMatch(notFoundHTML, /View As/);
     assert.match(fsHTML, /src=\.\.\/assets\//);
     assert.match(notFoundHTML, /src=\.\/assets\//);

--- a/packages/react/src/html/ui/components/MetaBar/index.jsx
+++ b/packages/react/src/html/ui/components/MetaBar/index.jsx
@@ -37,7 +37,7 @@ const HeadingValue = ({ value, stability }) => {
         size="small"
         className={styles.badge}
         kind={STABILITY_KINDS[stability]}
-        data-tooltip={STABILITY_TOOLTIPS[stability]}
+        title={STABILITY_TOOLTIPS[stability]}
         aria-label={ariaLabel}
         tabIndex={0}
       >


### PR DESCRIPTION
## Summary

- use the browser-native `title` tooltip for stability badges in the meta bar
- keep the existing accessible label and keyboard focus behavior
- add a generated-HTML regression test and a patch changeset

## Why

The shared CSS tooltip is rendered inside the meta bar's scrolling table of
contents. When a stability badge wraps near either horizontal edge, that
container clips part of the tooltip. A native tooltip is rendered outside the
scroll container, so its text remains fully visible without adding client-side
JavaScript to the otherwise static table of contents.

Fixes #938.

## Validation

- `prettier --check` on the changed files
- ESLint on the changed JavaScript files
- targeted web generator tests: 5 passed
- full test suite: 561 passed

AI assistance was used to investigate, implement, test, and review this change.
The commit includes an `Assisted-by: OpenAI Codex` attribution.
