### PR TITLE
fix(core): respect log level in worker threads

### DIFF
--- a/.changeset/worker-log-level.md
+++ b/.changeset/worker-log-level.md
@@ -1,0 +1,5 @@
+---
+'@doc-kit/core': patch
+---
+
+fix: respect `--log-level` in worker threads

--- a/packages/core/src/logger/__tests__/logger.test.mjs
+++ b/packages/core/src/logger/__tests__/logger.test.mjs
@@ -380,4 +380,35 @@ describe('createLogger', () => {
       strictEqual(transport.mock.callCount(), 1); // Debug should be filtered
     });
   });
+
+  describe('getLogLevel', () => {
+    it('should return the level the logger was created with', t => {
+      const logger = createLogger(t.mock.fn(), LogLevel.warn);
+
+      strictEqual(logger.getLogLevel(), LogLevel.warn);
+    });
+
+    it('should default to info when no level is given', t => {
+      const logger = createLogger(t.mock.fn());
+
+      strictEqual(logger.getLogLevel(), LogLevel.info);
+    });
+
+    it('should reflect a level set afterwards', t => {
+      const logger = createLogger(t.mock.fn(), LogLevel.info);
+
+      logger.setLogLevel('fatal');
+
+      strictEqual(logger.getLogLevel(), LogLevel.fatal);
+    });
+
+    it('should reflect the propagated level on children', t => {
+      const logger = createLogger(t.mock.fn(), LogLevel.info);
+      const child = logger.child('module');
+
+      logger.setLogLevel(LogLevel.error);
+
+      strictEqual(child.getLogLevel(), LogLevel.error);
+    });
+  });
 });

--- a/packages/core/src/logger/logger.mjs
+++ b/packages/core/src/logger/logger.mjs
@@ -165,6 +165,13 @@ export const createLogger = (
     }
   };
 
+  /**
+   * Gets the current log level for this logger instance.
+   *
+   * @returns {number} The current numeric log level
+   */
+  const getLogLevel = () => currentLevel;
+
   return {
     info,
     warn,
@@ -173,5 +180,6 @@ export const createLogger = (
     debug,
     child,
     setLogLevel,
+    getLogLevel,
   };
 };

--- a/packages/core/src/threading/__tests__/fixtures/log-level-reporter.mjs
+++ b/packages/core/src/threading/__tests__/fixtures/log-level-reporter.mjs
@@ -1,0 +1,19 @@
+import logger from '#logger/index.mjs';
+
+/**
+ * Test generator that reports the log level seen inside the worker, so the
+ * propagation of the level across the thread boundary can be asserted.
+ *
+ * @type {GeneratorMetadata<unknown, number[]>}
+ */
+export default {
+  name: 'log-level-reporter',
+  version: '1.0.0',
+  description: 'Reports the log level active inside the worker',
+  dependsOn: 'ast',
+  processChunk: async (_input, itemIndices) =>
+    itemIndices.map(() => logger.getLogLevel()),
+  async generate() {
+    return [logger.getLogLevel()];
+  },
+};

--- a/packages/core/src/threading/__tests__/index.test.mjs
+++ b/packages/core/src/threading/__tests__/index.test.mjs
@@ -1,0 +1,83 @@
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { LogLevel } from '../../logger/constants.mjs';
+import logger from '../../logger/index.mjs';
+import createWorkerPool from '../index.mjs';
+
+const reporterSpecifier = fileURLToPath(
+  import.meta.resolve('./fixtures/log-level-reporter.mjs')
+);
+
+/**
+ * Runs a function with the logger temporarily set to the given level.
+ *
+ * @template T
+ * @param {number} level - Log level to apply for the duration of the callback
+ * @param {() => Promise<T>} fn - Callback to run
+ * @returns {Promise<T>}
+ */
+const withLogLevel = async (level, fn) => {
+  const original = logger.getLogLevel();
+
+  logger.setLogLevel(level);
+
+  try {
+    return await fn();
+  } finally {
+    logger.setLogLevel(original);
+  }
+};
+
+describe('createWorkerPool', () => {
+  it('should forward the current log level to workers', async () => {
+    await withLogLevel(LogLevel.fatal, async () => {
+      const pool = createWorkerPool(1);
+
+      try {
+        strictEqual(pool.options.workerData.logLevel, LogLevel.fatal);
+      } finally {
+        await pool.destroy();
+      }
+    });
+  });
+
+  it('should apply the forwarded log level inside the worker', async () => {
+    await withLogLevel(LogLevel.fatal, async () => {
+      const pool = createWorkerPool(1);
+
+      try {
+        const [levelInWorker] = await pool.run({
+          generatorSpecifier: reporterSpecifier,
+          input: [null],
+          itemIndices: [0],
+          extra: {},
+          configuration: {},
+        });
+
+        strictEqual(levelInWorker, LogLevel.fatal);
+      } finally {
+        await pool.destroy();
+      }
+    });
+  });
+
+  it('should leave workers at the default level when it is not changed', async () => {
+    const pool = createWorkerPool(1);
+
+    try {
+      const [levelInWorker] = await pool.run({
+        generatorSpecifier: reporterSpecifier,
+        input: [null],
+        itemIndices: [0],
+        extra: {},
+        configuration: {},
+      });
+
+      strictEqual(levelInWorker, LogLevel.info);
+    } finally {
+      await pool.destroy();
+    }
+  });
+});

--- a/packages/core/src/threading/chunk-worker.mjs
+++ b/packages/core/src/threading/chunk-worker.mjs
@@ -1,5 +1,12 @@
+import { workerData } from 'node:worker_threads';
+
 import { loadGenerator } from '#generators/loader.mjs';
+import logger from '#logger/index.mjs';
 import { setConfig } from '#utils/configuration/index.mjs';
+
+if (workerData?.logLevel !== undefined) {
+  logger.setLogLevel(workerData.logLevel);
+}
 
 /**
  * Processes a chunk of items using the specified generator's processChunk method.

--- a/packages/core/src/threading/index.mjs
+++ b/packages/core/src/threading/index.mjs
@@ -23,5 +23,6 @@ export default function createWorkerPool(threads) {
     minThreads: 0,
     maxThreads: threads,
     idleTimeout: 1_000,
+    workerData: { logLevel: logger.getLogLevel() },
   });
 }


### PR DESCRIPTION
**What**

`--log-level` had no effect on warnings coming from worker threads.

```bash
npx @doc-kit/cli generate -t web -o out -i <node>/doc/api/ --log-level fatal
```

printed 81 `WARN` lines instead of none.

**Why**

The level is applied on the main thread only. Worker threads load their own module graph, so the default logger export creates a separate instance there that keeps the default `info` level. The warnings in the report come from `resolveTypes.mjs`, which runs inside the workers.

The same input makes it clear:

| Input | Workers used | default level | `--log-level fatal` |
| --- | --- | --- | --- |
| single file | no | 6 WARN | **0 WARN** |
| directory (`doc/api/`) | yes | 81 WARN | **81 WARN** |

Both inputs produce warnings, but only the single file respects the requested level. `parallel.mjs` skips the pool when `threads <= 1 || items.length <= 2`, so running the directory with `--threads 1` silences the warnings as well.

**How**

The level is passed through Piscina `workerData` and applied at the worker entry point. This adds a small `getLogLevel()` accessor, as there was no way to read the configured level back.

I also considered putting the level into `configuration`, which already reaches the workers, but `createTask` deliberately narrows what it sends:

```js
// Only pass the needed configuration to this generator
configuration: {
  [generatorName]: configuration[generatorName],
},
```

Sending the level that way would repeat it for every chunk, while `workerData` is sent once per worker.

**Verification**

| Case | Before | After |
| --- | --- | --- |
| `--log-level fatal` | 81 WARN | 0 WARN |
| default level | 81 WARN | 81 WARN |

The default level is unchanged, so nothing is silenced that should not be. Full suite passes (560 tests), lint and format checks are clean.

Fixes: https://github.com/nodejs/doc-kit/issues/1032
