### PR TITLE
fix(html): list pages without a document-level stability index

### DIFF
--- a/.changeset/index-page-missing-docs.md
+++ b/.changeset/index-page-missing-docs.md
@@ -1,0 +1,5 @@
+---
+'@doc-kit/generator-react': patch
+---
+
+fix(html): list pages without a document-level stability index

--- a/packages/react/src/html/ui/components/DocumentationIndex/index.jsx
+++ b/packages/react/src/html/ui/components/DocumentationIndex/index.jsx
@@ -9,7 +9,8 @@ import { documentationIndex } from '#theme/config';
  * @typedef {Object} DocumentationIndexEntry
  * @property {string} api - Basename of the document, linked as `${api}.html`
  * @property {string} name - Human-readable name from the document's heading
- * @property {string} index - Stability index (e.g. `'2'` or `'1.1'`)
+ * @property {string} [index] - Stability index (e.g. `'2'` or `'1.1'`), absent
+ * on documents that carry stability only on their individual sections
  * @property {string} [description] - The document's `llm_description`, or its
  * first paragraph, rendered to HTML at build time
  */
@@ -26,13 +27,15 @@ const IndexEntry = ({ api, name, index, description }) => {
       <span className={styles.title}>
         <span className={styles.name}>{name}</span>
 
-        <Badge
-          size="small"
-          kind={STABILITY_KINDS[level] ?? 'neutral'}
-          aria-label={`Stability: ${index}`}
-        >
-          {label}
-        </Badge>
+        {index !== undefined && (
+          <Badge
+            size="small"
+            kind={STABILITY_KINDS[level] ?? 'neutral'}
+            aria-label={`Stability: ${index}`}
+          >
+            {label}
+          </Badge>
+        )}
       </span>
 
       {description && (

--- a/packages/react/src/html/utils/__tests__/config.test.mjs
+++ b/packages/react/src/html/utils/__tests__/config.test.mjs
@@ -52,6 +52,7 @@ const makeEntry = (api, name, path, extra = {}) => ({
   api,
   path,
   heading: { depth: 1, data: { name } },
+  content: { type: 'root', children: [] },
   ...extra,
 });
 
@@ -131,7 +132,7 @@ describe('buildPageList', () => {
 });
 
 describe('buildDocumentationIndex', () => {
-  it('lists only pages with a stability index, with their descriptions', () => {
+  it('lists every page but the index itself, with their descriptions', () => {
     const input = [
       {
         api: 'fs',
@@ -179,6 +180,46 @@ describe('buildDocumentationIndex', () => {
         name: 'QUIC',
         index: '1.1',
         description: 'QUIC protocol support.',
+      },
+    ]);
+  });
+
+  it('keeps pages that carry no document-level stability index', () => {
+    // `process` and `errors` are documented this way: stability lives on their
+    // individual sections rather than on the document.
+    const input = [
+      {
+        api: 'process',
+        path: '/process',
+        heading: { depth: 1, data: { name: 'Process' } },
+        stability: null,
+        llm_description: 'Information about the current process.',
+        content: { type: 'root', children: [] },
+      },
+      {
+        api: 'fs',
+        path: '/fs',
+        heading: { depth: 1, data: { name: 'File System' } },
+        stability: { data: { index: '2' } },
+        llm_description: 'File system APIs.',
+        content: { type: 'root', children: [] },
+      },
+    ];
+
+    const result = buildDocumentationIndex(input);
+
+    assert.deepStrictEqual(result, [
+      {
+        api: 'fs',
+        name: 'File System',
+        index: '2',
+        description: 'File system APIs.',
+      },
+      {
+        api: 'process',
+        name: 'Process',
+        index: undefined,
+        description: 'Information about the current process.',
       },
     ]);
   });

--- a/packages/react/src/html/utils/config.mjs
+++ b/packages/react/src/html/utils/config.mjs
@@ -116,18 +116,22 @@ export function buildChunkGroups(input) {
 
 /**
  * Pre-compute the entries rendered by the `<DocumentationIndex />` component:
- * every page with a stability index, plus its description.
+ * every page other than the index itself, plus its description.
+ *
+ * A document-level stability index is optional. Documents such as `process`
+ * and `errors` carry stability only on their individual sections, and pages
+ * that list them by document, this one included, still need to link to them.
  *
  * @param {Array<import('@doc-kit/core/generators/metadata/types').MetadataEntry>} input
- * @returns {Array<{api: string, name: string, index: string, description: string}>}
+ * @returns {Array<{api: string, name: string, index: string | undefined, description: string}>}
  */
 export function buildDocumentationIndex(input) {
   return getSortedHeadNodes(input)
-    .filter(entry => entry.stability)
+    .filter(entry => entry.api !== 'index')
     .map(entry => ({
       api: entry.api,
       name: entry.heading.data.name,
-      index: entry.stability.data.index,
+      index: entry.stability?.data.index,
       description: renderAsHTML(parseInline(getEntryDescription(entry), true)),
     }));
 }


### PR DESCRIPTION
## Description

**What**

The generated index page drops every document that has no document-level stability index. Against the current `nodejs/node` docs that is 13 of 68 pages:

`module` (the one this issue reports), `process`, `errors`, `cli`, `deprecations`, `packages`, `permissions`, `v8`, `intl`, `addons`, `embedding`, `environment_variables`, `documentation`.

**Why**

`buildDocumentationIndex()` keeps only entries that carry a stability index:

```js
return getSortedHeadNodes(input)
  .filter(entry => entry.stability)
```

A document-level stability index is optional, and having none says nothing about whether a page belongs in a listing of the documentation. These pages place stability on their individual sections instead:

| Document | `> Stability:` occurrences in the file |
| --- | --- |
| `cli.md` | 50 |
| `process.md` | 20 |
| `errors.md` | 15 |
| `module.md` | 7 |

`cli` carries 50 of them and is still dropped, because none of them sit at the document level.

The sidebar disagrees with the index page on this. `buildPageList()`, one function above and fed the same input, applies no such filter and lists all 68.

**How**

List every page, excluding only `index` itself, which is the page doing the listing. That exclusion follows the existing pattern in `jsx-ast/generate.mjs`:

```js
const moduleInput = input.filter(
  entry => entry.api !== 'index' && !entry.chunk
);
```

The stability badge now renders only when the entry has an index. Without that guard `parseInt(undefined, 10)` gives `NaN`, which renders an empty badge and reads out as `Stability: undefined` to a screen reader.

One test helper needed a fix: `makeEntry()` built entries without `content`, which the old filter happened to screen out. `content` is not optional in `MetadataEntry`, so the helper now matches the real shape rather than the code guarding against something the pipeline cannot produce.

## Validation

Built the current `nodejs/node` docs before and after:

```bash
node packages/cli/bin/cli.mjs generate \
  -i "<node>/doc/api/*.md" -t html -o out \
  --index "<node>/doc/api/index.md" \
  -v v26.0.0 -c https://github.com/nodejs/node/releases
```

| | Before | After |
| --- | --- | --- |
| Pages generated | 68 | 68 |
| Pages listed on the index | 55 | **68** |
| Missing | **13** | **0** |
| `index` itself listed | no | no |

The output contains no `Stability: undefined` and no `NaN`. The 12 entries without an index render with no badge.

`node --run test` reports 571/575. The 4 failures (`core/generators`, `react/html`, `section-pages` x2) are present on `main` as well: 570/574 there, so this adds one test and one pass and leaves the failure count unchanged. None of them touch the files in this PR.

## Related Issues

Fixes https://github.com/nodejs/doc-kit/issues/1055

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format:check` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
