### PR TITLE
fix(react): hydrate search on idle for keyboard shortcuts

### DIFF
--- a/packages/react/src/html/__tests__/generate.test.mjs
+++ b/packages/react/src/html/__tests__/generate.test.mjs
@@ -72,7 +72,8 @@ const createTestConfiguration = async (context, target = ['html']) => {
 
 describe('web generate', () => {
   it('writes bundled HTML and omits View As links for synthetic pages', async context => {
-    const { output } = await createTestConfiguration(context);
+    const { config, output } = await createTestConfiguration(context);
+    config.html.showSearchBox = true;
     const fs = createEntry('fs', 'File system');
     fs.path = '/api/fs';
     const notFoundPage = buildNotFoundPage();
@@ -94,6 +95,7 @@ describe('web generate', () => {
     assert.doesNotMatch(notFoundHTML, /View As/);
     assert.match(fsHTML, /src=\.\.\/assets\//);
     assert.match(notFoundHTML, /src=\.\/assets\//);
+    assert.match(fsHTML, /on:idle[^>]*data-island-name=SearchBox/);
   });
 
   it('renders chunk pages with navigation back to their module', async context => {

--- a/packages/react/src/html/ui/components/SearchBox/index.jsx
+++ b/packages/react/src/html/ui/components/SearchBox/index.jsx
@@ -100,5 +100,5 @@ const SearchBox = ({ pathname }) => {
 
 export default withIsland(SearchBox, {
   name: 'SearchBox',
-  on: { interaction: 'pointerover,focusin,touchstart' },
+  on: { idle: true },
 });


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes the <kbd>Cmd/Ctrl+K</kbd> for the Beta Docs page https://beta.docs.nodejs.org.

The search box currently hydrates only after `pointerover`, `focusin`, or `touchstart`. As a result, the <kbd>Cmd/Ctrl+K</kbd> listener is not registered until the user interacts with the search button, so the shortcut can appear to work intermittently.

Hydrate the search box on idle instead, allowing the shortcut to work without requiring prior interaction. The Orama database remains lazy-loaded until the first search.

## Validation

Open the Beta Docs page, and press the <kbd>Cmd/Ctrl+K</kbd> immediately. Nothing should have happened until you `pointerover/focusin/touchstart` the search box.

## Related Issues

None

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format:check` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
