### PR TITLE
fix: normalize paths in Windows tests

### DIFF
--- a/packages/core/src/generators/ast/generate.mjs
+++ b/packages/core/src/generators/ast/generate.mjs
@@ -1,7 +1,7 @@
 'use strict';
 
 import { readFile } from 'node:fs/promises';
-import { relative, sep } from 'node:path/posix';
+import { relative, sep } from 'node:path';
 
 import globParent from 'glob-parent';
 import { globSync } from 'tinyglobby';
@@ -65,7 +65,7 @@ export async function processChunk(inputSlice, itemIndices) {
     );
 
     // The path is the relative path minus the extension
-    const relativePath = sep + withExt(relative(parent, path));
+    const relativePath = `/${withExt(relative(parent, path)).replaceAll(sep, '/')}`;
 
     let tree;
 

--- a/packages/react/src/html/utils/copying.mjs
+++ b/packages/react/src/html/utils/copying.mjs
@@ -28,7 +28,7 @@ export async function copyStaticAssets(config) {
         } catch (err) {
           if (err.code !== 'ENOENT') {
             logger.error(
-              `[html-generator] Failed to copy asset from ${src} to ${dest}: ${err.message}`
+              `[html-generator] Failed to copy asset from ${src} to ${dest.replaceAll('\\', '/')}: ${err.message}`
             );
           }
         }

--- a/scripts/comparators/file-size.mjs
+++ b/scripts/comparators/file-size.mjs
@@ -65,9 +65,8 @@ if (changed.length) {
       base === 0 ? '' : ` (${sign}${((diff / base) * 100).toFixed(1)}%)`;
     const diffFormatted = `${sign}${formatBytes(diff)}${percent}`;
 
-    return `| \`${file}\` | ${baseStats.has(file) ? formatBytes(base) : '—'} | ${headStats.has(file) ? formatBytes(head) : '—'} | ${diffFormatted} |`;
+    return `| \`${file.replace(/\\/g, '/')}\` | ${baseStats.has(file) ? formatBytes(base) : '—'} | ${headStats.has(file) ? formatBytes(head) : '—'} | ${diffFormatted} |`;
   });
-
   sections.push(
     [
       `**Output size:** ${changed.length} ${changed.length === 1 ? 'file' : 'files'} changed · net ${totalSign}${formatBytes(totalDiff)}`,

--- a/scripts/comparators/object-assertion.mjs
+++ b/scripts/comparators/object-assertion.mjs
@@ -18,11 +18,11 @@ export const details = (summary, diff) =>
 
 const getFileDiff = async file => {
   if (!baseFileSet.has(file)) {
-    return `- \`${file}\` added`;
+    return `- \`${file.replace(/\\/g, '/')}\` added`;
   }
 
   if (!headFileSet.has(file)) {
-    return `- \`${file}\` removed`;
+    return `- \`${file.replace(/\\/g, '/')}\` removed`;
   }
 
   const basePath = join(BASE, file);


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Normalize file paths to use forward slashes in output comparisons, ensuring tests behave consistently on Windows.

This updates the affected generators and comparators to avoid Windows-specific backslash paths in test output.

## Validation

- [x] Ran `node --run test` — all 598 tests passed.
- [x] Ran `node --run format:check` — passed.
- [x] Ran `node --run lint` — passed.

## Related Issues


N/A

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format:check` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
