### PR TITLE
refactor(core): simplify parsers with Array.from map function

### DIFF
--- a/packages/core/src/parsers/markdown.mjs
+++ b/packages/core/src/parsers/markdown.mjs
@@ -22,9 +22,7 @@ const NODE_LTS_VERSION_REGEX = /Long Term Support/i;
 export const parseChangelog = async path => {
   const changelog = await loadFromURL(path);
 
-  const nodeMajors = Array.from(changelog.matchAll(NODE_VERSIONS_REGEX));
-
-  return nodeMajors.map(match => ({
+  return Array.from(changelog.matchAll(NODE_VERSIONS_REGEX), match => ({
     version: coerce(match[1]),
     isLts: NODE_LTS_VERSION_REGEX.test(match[2]),
   }));
@@ -43,7 +41,8 @@ export const parseIndex = async path => {
 
   const index = await loadFromURL(path);
 
-  const items = Array.from(index.matchAll(LIST_ITEM_REGEX));
-
-  return items.map(([, section, api]) => ({ section, api }));
+  return Array.from(index.matchAll(LIST_ITEM_REGEX), ([, section, api]) => ({
+    section,
+    api,
+  }));
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Replace intermediate `Array.from(...).map(...)` chains in parseChangelog and parseIndex with Array.from(iterable, mapFn), removing the extra intermediate array allocation.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#mapfn
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
