### PR TITLE
fix: confine code block horizontal scrolling to the code

### DIFF
--- a/.changeset/code-block-scroll.md
+++ b/.changeset/code-block-scroll.md
@@ -1,0 +1,6 @@
+---
+'@doc-kit/core': patch
+'@node-core/doc-kit-legacy': patch
+---
+
+Confine horizontal scrolling in code blocks to the code itself, so the toolbar no longer scrolls out of view along with a long line.

--- a/packages/core/src/utils/highlighter.mjs
+++ b/packages/core/src/utils/highlighter.mjs
@@ -114,6 +114,11 @@ export default function rehypeShikiji() {
       // Adds the original language back to the <pre> element
       children[0].properties.class = `${children[0].properties.class} ${codeLanguage}`;
 
+      // The <code> element is the one that scrolls horizontally, so it is the
+      // one that has to be reachable by keyboard
+      delete children[0].properties.tabindex;
+      children[0].children[0].properties.tabindex = 0;
+
       // Adds the toolbar (language label + copy button) to the <pre> element
       children[0].children.push(createToolbarElement(languageId));
 

--- a/packages/node-legacy/src/legacy-html/assets/style.css
+++ b/packages/node-legacy/src/legacy-html/assets/style.css
@@ -544,11 +544,13 @@ pre {
   vertical-align: top;
   border-radius: 4px;
   margin: 1rem;
-  overflow-x: auto;
 }
 
+/* Only the code scrolls, so the toolbar stays put */
 pre > code {
+  display: block;
   padding: 0;
+  overflow-x: auto;
 }
 
 pre + h3 {


### PR DESCRIPTION
When scrolling horizontally, the footer scrolls too.
<img width="824" height="632" alt="image" src="https://github.com/user-attachments/assets/537da999-4a39-4e0d-a2a3-c80c1fcc4e70" />

This PR fixes that

`pre` was the scroll container for code blocks, so a single long line scrolled the whole block — taking the toolbar (language label and copy button) out of view with it. This moves `overflow-x: auto` down to the `code` element so only the code scrolls.

Shiki puts `tabindex="0"` on the `<pre>` so the scrollable region is keyboard-reachable; that moves to the `<code>` element along with the scrolling, otherwise it is left on an element that no longer scrolls.