### PR TITLE
fix: show a focus outline on the copy button

### DIFF
--- a/.changeset/copy-button-focus.md
+++ b/.changeset/copy-button-focus.md
@@ -1,0 +1,5 @@
+---
+'@node-core/doc-kit-legacy': patch
+---
+
+Show a focus outline on the code block copy button

--- a/packages/node-legacy/src/legacy-html/assets/style.css
+++ b/packages/node-legacy/src/legacy-html/assets/style.css
@@ -1032,7 +1032,6 @@ kbd {
 }
 
 .copy-button {
-  outline: none;
   font-size: 10px;
   color: #fff;
   background-color: var(--green1);
@@ -1053,6 +1052,11 @@ kbd {
 
 .copy-button:hover {
   background-color: var(--green2);
+}
+
+.copy-button:focus-visible {
+  outline: 2px solid var(--color-text-primary);
+  outline-offset: 2px;
 }
 
 :root:not(.has-js) .copy-button {


### PR DESCRIPTION
the copy button was not showing it was focused. making it inaccessible to keyboard users.
before:
<img width="352" height="142" alt="image" src="https://github.com/user-attachments/assets/82d582c2-8bb7-4834-9be4-94648d044282" />
<img width="344" height="124" alt="image" src="https://github.com/user-attachments/assets/282c540a-d9bc-489d-b8b2-dbc61fb34a5a" />

after:
<img width="390" height="140" alt="image" src="https://github.com/user-attachments/assets/9cd65fcc-71c6-4f24-8c75-0ae1caf20c25" />
<img width="352" height="124" alt="image" src="https://github.com/user-attachments/assets/b6c1c8fd-99fd-4f6f-b57e-7a96ec4b411f" />


`.copy-button` set `outline: none` unconditionally, so the code block copy button was reachable by keyboard but gave no visible indication of focus.

This drops the blanket `outline: none` and draws an explicit ring on `:focus-visible`, so it appears for keyboard users without showing up on mouse clicks. The ring uses `--color-text-primary`, which is already theme-aware, so it contrasts against the code block in both light and dark mode.