### PR TITLE
test: support platform-specific paths

### DIFF
--- a/packages/core/src/generators/ast/__tests__/generate.test.mjs
+++ b/packages/core/src/generators/ast/__tests__/generate.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
 import { STABILITY_INDEX_URL } from '../constants.mjs';
@@ -9,12 +9,14 @@ import { processChunk } from '../generate.mjs';
 
 let dir;
 
+const toPosixPath = value => value.split(sep).join('/');
+
 // Writes `content` to `<name>` in the temp dir and returns the
 // `[path, parent]` tuple `processChunk` expects.
 const file = async (name, content) => {
   const path = join(dir, name);
   await writeFile(path, content);
-  return [path, dir];
+  return [toPosixPath(path), toPosixPath(dir)];
 };
 
 // Runs a single file through `processChunk` and returns its result entry.

--- a/packages/react/src/html/utils/__tests__/copying.test.mjs
+++ b/packages/react/src/html/utils/__tests__/copying.test.mjs
@@ -118,9 +118,9 @@ describe('copyStaticAssets', () => {
     assert.strictEqual(mockLogError.mock.callCount(), 1);
 
     const logMessage = mockLogError.mock.calls[0].arguments[0];
-    assert.match(
+    assert.equal(
       logMessage,
-      /\[html-generator\] Failed to copy asset from protected-file to \/out\/protected-file: Permission denied/
+      `[html-generator] Failed to copy asset from protected-file to ${join('/out', 'protected-file')}: Permission denied`
     );
   });
 });

--- a/scripts/__tests__/comparators.test.mjs
+++ b/scripts/__tests__/comparators.test.mjs
@@ -163,10 +163,20 @@ test('comparators report added and removed output files', async t => {
   ]);
 
   assert.match(sizes, /2 files changed/);
-  assert.match(sizes, /`generator\/added\.json` \| — \| 12\.00 B/);
-  assert.match(sizes, /`generator\/removed\.json` \| 12\.00 B \| —/);
-  assert.match(objects, /`generator\/added\.json` added/);
-  assert.match(objects, /`generator\/removed\.json` removed/);
+  const added = `generator${path.sep}added.json`;
+  const removed = `generator${path.sep}removed.json`;
+  const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  assert.match(
+    sizes,
+    new RegExp(`\`${escapeRegExp(added)}\` \\| — \\| 12\\.00 B`)
+  );
+  assert.match(
+    sizes,
+    new RegExp(`\`${escapeRegExp(removed)}\` \\| 12\\.00 B \\| —`)
+  );
+  assert.match(objects, new RegExp(`\`${escapeRegExp(added)}\` added`));
+  assert.match(objects, new RegExp(`\`${escapeRegExp(removed)}\` removed`));
   assert.doesNotMatch(sizes, /comparison\.txt|4\.00 KB/);
   assert.doesNotMatch(objects, /comparison\.txt/);
 });


### PR DESCRIPTION
Use environment-aware path handling in Windows-sensitive test assertions while preserving the source behavior.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `node --run test` and all tests passed.
- [x] I have check code formatting with `node --run format:check` & `node --run lint`.
- [x] I've covered new added functionality with unit tests if necessary.
