### PR TITLE
perf(core): overlap file reads within ast generator chunks

### DIFF
--- a/packages/core/src/generators/ast/generate.mjs
+++ b/packages/core/src/generators/ast/generate.mjs
@@ -51,10 +51,15 @@ const isMdxFile = (path, content) => {
 export async function processChunk(inputSlice, itemIndices) {
   const filePaths = itemIndices.map(idx => inputSlice[idx]);
 
+  // Reads overlap within the chunk; parsing below stays sequential.
+  const contents = await Promise.all(
+    filePaths.map(([path]) => readFile(path, 'utf-8'))
+  );
+
   const results = [];
 
-  for (const [path, parent] of filePaths) {
-    const content = await readFile(path, 'utf-8');
+  for (const [i, [path, parent]] of filePaths.entries()) {
+    const content = contents[i];
 
     const mdx = isMdxFile(path, content);
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/doc-kit/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
processChunk awaited one file read at a time, so I/O within a chunk was fully serialized. Reads now run concurrently via Promise.all, bounded by the chunk size; parsing remains sequential. 
<!-- Write a brief description of the changes introduced by this PR -->

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/doc-kit/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `node --run test` and all tests passed.
- [ ] I have check code formatting with `node --run format:check` & `node --run lint`.
- [ ] I've covered new added functionality with unit tests if necessary.
